### PR TITLE
shell command now can handle spaces in them.

### DIFF
--- a/Slate/Constants.h
+++ b/Slate/Constants.h
@@ -299,6 +299,7 @@ extern NSString *const EMPTY;
 extern NSString *const PIPE_PADDED;
 extern NSString *const GREATER_THAN_PADDED;
 extern NSString *const QUOTES;
+extern NSString *const SPACE_WORD;
 extern NSString *const EQUALS;
 extern NSString *const TILDA;
 extern NSString *const SLASH;

--- a/Slate/Constants.m
+++ b/Slate/Constants.m
@@ -299,6 +299,7 @@ NSString *const EMPTY = @"";
 NSString *const PIPE_PADDED = @" | ";
 NSString *const GREATER_THAN_PADDED = @" > ";
 NSString *const QUOTES = @"'\"";
+NSString *const SPACE_WORD= @"<space>";
 NSString *const EQUALS = @"=";
 NSString *const TILDA = @"~";
 NSString *const SLASH = @"/";

--- a/Slate/ShellOperation.m
+++ b/Slate/ShellOperation.m
@@ -132,9 +132,9 @@
     }
   }
   NSString *commandAndArgs = [tokens lastObject];
-  NSString *c = [commandAndArgs stringByReplacingOccurrencesOfString:@"\\ " withString:SPACE_WORD];
+  NSString *commandAndArgsWithSpaceWord = [commandAndArgs stringByReplacingOccurrencesOfString:@"\\ " withString:SPACE_WORD];
   NSMutableArray *commandAndArgsTokens = [NSMutableArray array];
-  [StringTokenizer tokenize:c into:commandAndArgsTokens];
+  [StringTokenizer tokenize:commandAndArgsWithSpaceWord into:commandAndArgsTokens];
   if ([commandAndArgsTokens count] < 1) {
     SlateLogger(@"ERROR: Invalid Parameters '%@'", shellOperation);
     @throw([NSException exceptionWithName:@"Invalid Parameters" reason:[NSString stringWithFormat:@"Invalid Parameters in '%@'. Shell operations require the following format: shell [wait] 'command'", shellOperation] userInfo:nil]);
@@ -144,7 +144,7 @@
   NSMutableArray *args = [NSMutableArray array];
   for (NSInteger i = 1; i < [commandAndArgsTokens count]; i++) {
       
-    [args addObject:[[commandAndArgsTokens objectAtIndex:i] stringByReplacingOccurrencesOfString:@"<space>" withString:@" "]];
+    [args addObject:[[commandAndArgsTokens objectAtIndex:i] stringByReplacingOccurrencesOfString:SPACE_WORD withString:@" "]];
   }
 
   Operation *op = [[ShellOperation alloc] initWithCommand:command args:args waitForExit:waitForExit currentPath:currentPath];

--- a/Slate/ShellOperation.m
+++ b/Slate/ShellOperation.m
@@ -132,7 +132,7 @@
     }
   }
   NSString *commandAndArgs = [tokens lastObject];
-  NSString *c = [commandAndArgs stringByReplacingOccurrencesOfString:@"\\ " withString:@"<space>"];
+  NSString *c = [commandAndArgs stringByReplacingOccurrencesOfString:@"\\ " withString:SPACE_WORD];
   NSMutableArray *commandAndArgsTokens = [NSMutableArray array];
   [StringTokenizer tokenize:c into:commandAndArgsTokens];
   if ([commandAndArgsTokens count] < 1) {
@@ -140,7 +140,7 @@
     @throw([NSException exceptionWithName:@"Invalid Parameters" reason:[NSString stringWithFormat:@"Invalid Parameters in '%@'. Shell operations require the following format: shell [wait] 'command'", shellOperation] userInfo:nil]);
   }
   NSString *command = [commandAndArgsTokens objectAtIndex:0];
-  command = [command stringByReplacingOccurrencesOfString:@"<space>" withString:@" "];
+    command = [command stringByReplacingOccurrencesOfString:SPACE_WORD withString:@" "];
   NSMutableArray *args = [NSMutableArray array];
   for (NSInteger i = 1; i < [commandAndArgsTokens count]; i++) {
       

--- a/Slate/ShellOperation.m
+++ b/Slate/ShellOperation.m
@@ -132,7 +132,7 @@
     }
   }
   NSString *commandAndArgs = [tokens lastObject];
-    NSString *c = [commandAndArgs stringByReplacingOccurrencesOfString:@"\\ " withString:@"<space>"];
+  NSString *c = [commandAndArgs stringByReplacingOccurrencesOfString:@"\\ " withString:@"<space>"];
   NSMutableArray *commandAndArgsTokens = [NSMutableArray array];
   [StringTokenizer tokenize:c into:commandAndArgsTokens];
   if ([commandAndArgsTokens count] < 1) {
@@ -140,7 +140,7 @@
     @throw([NSException exceptionWithName:@"Invalid Parameters" reason:[NSString stringWithFormat:@"Invalid Parameters in '%@'. Shell operations require the following format: shell [wait] 'command'", shellOperation] userInfo:nil]);
   }
   NSString *command = [commandAndArgsTokens objectAtIndex:0];
-    command = [command stringByReplacingOccurrencesOfString:@"<space>" withString:@" "];
+  command = [command stringByReplacingOccurrencesOfString:@"<space>" withString:@" "];
   NSMutableArray *args = [NSMutableArray array];
   for (NSInteger i = 1; i < [commandAndArgsTokens count]; i++) {
       

--- a/Slate/ShellOperation.m
+++ b/Slate/ShellOperation.m
@@ -132,16 +132,19 @@
     }
   }
   NSString *commandAndArgs = [tokens lastObject];
+    NSString *c = [commandAndArgs stringByReplacingOccurrencesOfString:@"\\ " withString:@"<space>"];
   NSMutableArray *commandAndArgsTokens = [NSMutableArray array];
-  [StringTokenizer tokenize:commandAndArgs into:commandAndArgsTokens];
+  [StringTokenizer tokenize:c into:commandAndArgsTokens];
   if ([commandAndArgsTokens count] < 1) {
     SlateLogger(@"ERROR: Invalid Parameters '%@'", shellOperation);
     @throw([NSException exceptionWithName:@"Invalid Parameters" reason:[NSString stringWithFormat:@"Invalid Parameters in '%@'. Shell operations require the following format: shell [wait] 'command'", shellOperation] userInfo:nil]);
   }
   NSString *command = [commandAndArgsTokens objectAtIndex:0];
+    command = [command stringByReplacingOccurrencesOfString:@"<space>" withString:@" "];
   NSMutableArray *args = [NSMutableArray array];
   for (NSInteger i = 1; i < [commandAndArgsTokens count]; i++) {
-    [args addObject:[commandAndArgsTokens objectAtIndex:i]];
+      
+    [args addObject:[[commandAndArgsTokens objectAtIndex:i] stringByReplacingOccurrencesOfString:@"<space>" withString:@" "]];
   }
 
   Operation *op = [[ShellOperation alloc] initWithCommand:command args:args waitForExit:waitForExit currentPath:currentPath];


### PR DESCRIPTION
This fixes the problem of being able to run
`bind b:${launcher} shell '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome' `
from the keybindings. 
