### PR TITLE
sequence doesn't work when a windowless app has focus

### DIFF
--- a/Slate/SequenceOperation.m
+++ b/Slate/SequenceOperation.m
@@ -57,7 +57,7 @@
 - (BOOL) doOperationWithAccessibilityWrapper:(AccessibilityWrapper *)iamnil screenWrapper:(ScreenWrapper *)sw {
   for (NSInteger i = 0; i < [[self operations] count]; i++) {
     AccessibilityWrapper *aw = [[AccessibilityWrapper alloc] init];
-    if (![aw inited]) return NO;
+    //if (![aw inited]) return NO;
     for (NSInteger j = 0; j < [[[self operations] objectAtIndex:i] count]; j++) {
       [[[[self operations] objectAtIndex:i] objectAtIndex:j] doOperationWithAccessibilityWrapper:aw screenWrapper:sw];
     }


### PR DESCRIPTION
Open Preview or Chrome, close all windows. Use something like:

```
bind i:cmd sequence focus 'iTerm'
```

With sequence, it doesn't work. Without it, it works.