### PR TITLE
Fix empty title window hints.

### DIFF
--- a/Slate/HintOperation.m
+++ b/Slate/HintOperation.m
@@ -319,11 +319,13 @@ CFComparisonResult rightToLeftWindows(const void *val1, const void *val2, void *
       CFArraySortValues(allWindows, CFRangeMake(0, CFArrayGetCount(allWindows)), rightToLeftWindows, NULL);
     }
     for (NSInteger i = 0; i < CFArrayGetCount(allWindows); i++) {
-      NSString *title = [AccessibilityWrapper getTitle:CFArrayGetValueAtIndex(allWindows, i)];
-      if (title == nil || [EMPTY isEqualToString:title]) continue; // skip empty title windows because they are invisible
-      SlateLogger(@"  Hinting Window: %@", title);
       CFTypeRef _window = CFArrayGetValueAtIndex(allWindows, i);
-      [self createHintWindowFor:(AXUIElementRef)_window inApp:[AccessibilityWrapper applicationForElement:(AXUIElementRef)_window] screenWrapper:sw];
+      NSString *title = [AccessibilityWrapper getTitle:_window];
+      AXUIElementRef appRef = [AccessibilityWrapper applicationForElement:(AXUIElementRef)_window];
+      BOOL isWindowMinimizedOrHidden = [AccessibilityWrapper isWindowMinimizedOrHidden:_window inApp:appRef];
+      if (title == nil || isWindowMinimizedOrHidden) continue; // skip nil title and minimized/hidden windows because they are invisible
+      SlateLogger(@"  Hinting Window: %@", title);
+      [self createHintWindowFor:(AXUIElementRef)_window inApp:appRef screenWrapper:sw];
     }
   }
 


### PR DESCRIPTION
Windows like iBooks and Spotify don't have a title set and a hint cannot be shown for those. Since I use window hints alot I decided to try to fix this. This is my very first time I've done anything and read Objective-C code! I have a fair amount of programming knowledge which helped me with this issue. Anyone with knowledge of Objective-C code: please look if I missed anything and or created bugs :)

This fixes issues #56 and #31.