### PR TITLE
Hide ghost windows of 1 by 1 pixels.

### DIFF
--- a/Slate/HintOperation.m
+++ b/Slate/HintOperation.m
@@ -101,6 +101,10 @@ static const UInt32 ESC_HINT_ID = 10001;
   AccessibilityWrapper *aw = [[AccessibilityWrapper alloc] initWithApp:appRef window:windowRef];
   NSPoint wTL = [aw getCurrentTopLeft];
   NSSize wSize = [aw getCurrentSize];
+  if (wSize.height == 1 && wSize.width == 1) {
+      SlateLogger(@"    Window is too small, not creating hint.");
+      return;
+  }
   // check corners and center to see which screen window is on
   NSInteger screenId = [sw getScreenIdForPoint:wTL];
   if (screenId < 0) screenId = [sw getScreenIdForPoint:NSMakePoint(wTL.x+wSize.width/2, wTL.y+wSize.height/2)];


### PR DESCRIPTION
After my PR #61 some "ghost" windows showed up. These windows where created by Chrome and when  focused show the current window. These windows are 1 x 1 pixels in width and height and are placed on the edge of the screen.
![screen shot 2016-02-15 at 19 04 48](https://cloud.githubusercontent.com/assets/1044316/13056822/2a64f4f8-d418-11e5-8836-4baafa5320eb.jpg)

The debug message for this window is:
```
2016-02-15 19:13:42.999 Slate[1849:38299]   Hinting Window: 
2016-02-15 19:13:42.999 Slate[1849:38299]     attempting to hint
2016-02-15 19:13:42.999 Slate[1849:38299]     GIVING CODE: B
2016-02-15 19:13:43.000 Slate[1849:38299] screenOrigin:(4,0), screenSize:(2556,1440), windowSize:(1.000000,1.000000), windowTopLeft:(890.000000,-21.000000)
2016-02-15 19:13:43.000 Slate[1849:38299]         Existing Window!
```

This PR is to hide these "ghost" windows by not creating a hint for windows that are 1 by 1 pixels.