### PR TITLE
Fix wrong hint icons references #26

### DIFF
--- a/Slate/HintOperation.m
+++ b/Slate/HintOperation.m
@@ -189,8 +189,10 @@ static const UInt32 ESC_HINT_ID = 10001;
     SlateLogger(@"        Existing Window!");
     NSWindowController *wc = [hints objectForKey:currentHintNumber];
     [[wc window] setFrame:NSMakeRect(frame.origin.x+screen.frame.origin.x, frame.origin.y+screen.frame.origin.y, frame.size.width, frame.size.height) display:NO];
-    HintView *label = (HintView*)[[wc window] contentView];
+    HintView *label = [[HintView alloc] initWithFrame:frame];
+    [label setText:hintCode];
     [label setIconFromAppRef:appRef];
+    [[wc window] setContentView:label];
     [wc showWindow:[wc window]];
   }
   [windows setObject:[NSValue valueWithPointer:windowRef] forKey:currentHintNumber];


### PR DESCRIPTION
This is more a workaround than a fix, but it presents my findings.
The problem with random icons appears only when slate tries to reuse existing windows and views. That is why people reported that simply restarting slate fixed windows some times.
The old code tries to extract view from window and apply new icon, but it just doesn't work.
However creating completely new HintView and assigning it to window works OK and fixes the problem.

I am not objective C developer, so I am not familiar with its memory management. Is it possible that HintView got deallocated and ignores `setIconFromAppRef` message?

If that is not the case my solution could introduce memory leaks because it creates and allocates memory for new view every time I am using window hinting.

