### PR TITLE
Fixed issue #70; undo PR #72

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Slate.xcodeproj/xcuserdata/jigish.xcuserdatad/
 *.xcuserdatad
 tmp
 doc/*.html
+.DS_Store

--- a/Slate/ResizeOperation.m
+++ b/Slate/ResizeOperation.m
@@ -72,8 +72,7 @@
   NSSize nSize = [self getDimensionsWithCurrentWindow:cWindowRect screenWrapper:sw];
   if (!NSEqualSizes(cSize, nSize)) {
       NSPoint nTopLeft = [self getTopLeftWithCurrentWindow:cWindowRect newSize:nSize];
-      success = [aw moveWindow:nTopLeft] && success;
-      success = [aw resizeWindow:nSize] && success;
+      success = [aw moveWindow:nTopLeft] && [aw resizeWindow:nSize];
   }
   return success;
 }


### PR DESCRIPTION
There is a bug in PR #72 (which aimed to fix Issue #70), which is that `success` always had the value `NO` because it was and-ed with itself, and its initial value was `NO`. This PR sets `success` correctly.