### PR TITLE
Default grid bindings

### DIFF
--- a/Slate/default.slate
+++ b/Slate/default.slate
@@ -44,5 +44,8 @@ bind down:cmd     focus down
 bind up:cmd;alt   focus behind
 bind down:cmd;alt focus behind
 
+# Grid Bindings
+bind space:cmd;shift grid padding:1 1920x1080:6,6 1440x900:6,6 2560x1600:6,6 2880x1800:6,6
+
 # Window Hints
 bind esc:cmd hint


### PR DESCRIPTION
This fixes the issue in #86 

It uses the same default bindings for the grid as Divvy (cmd + shift + space), and uses a 6 by 6 grid by default just like Divvy.
